### PR TITLE
Fix dataset creation

### DIFF
--- a/src/containers/ExperimentManager/ExperimentManagement.tsx
+++ b/src/containers/ExperimentManager/ExperimentManagement.tsx
@@ -126,7 +126,7 @@ class ExperimentManagement extends React.Component<
         alpha: experiment.parameters.alpha,
         independence_test: experiment.parameters.independence_test,
         cores: experiment.parameters.cores,
-        observationMatrix_id: experiment.observationMatrix_id,
+        observationMatrix_id: experiment.dataset_id,
       }
     })
   }
@@ -140,7 +140,7 @@ class ExperimentManagement extends React.Component<
         alpha: experiment.parameters.alpha,
         independence_test: experiment.parameters.independence_test,
         cores: experiment.parameters.cores,
-        observationMatrix_id: experiment.observationMatrix_id,
+        observationMatrix_id: experiment.dataset_id,
       }
     })
   }

--- a/src/containers/ExperimentManager/NewExperimentModal.tsx
+++ b/src/containers/ExperimentManager/NewExperimentModal.tsx
@@ -193,7 +193,7 @@ class NewExperimentModal extends React.Component<
 
   private submitExperiment = (values: IFormExperiment) => {
     createExperiment({
-      observationMatrix_id: values.observationMatrix_id,
+      dataset_id: values.observationMatrix_id,
       name: values.name,
       parameters: {
         alpha: values.alpha,

--- a/src/types/index.tsx
+++ b/src/types/index.tsx
@@ -38,8 +38,8 @@ export interface IObservationMatrix {
 }
 
 export interface IExperiment {
-  observationMatrix_id: number;
-  observationMatrix?: number;
+  dataset_id: number;
+  dataset?: number;
   id?: number;
   name: string;
   parameters: {


### PR DESCRIPTION
`observationMatrix_id` does not exist in the backend. Thus, the creation of experiments is failing. 
Fix: rename `observationMatrix_id` in `dataset_id`